### PR TITLE
Add 'Limitations' to page limit candidates

### DIFF
--- a/aclpubcheck/formatchecker.py
+++ b/aclpubcheck/formatchecker.py
@@ -321,7 +321,7 @@ class Formatter(object):
         # thresholds for different types of papers
         standards = {"short": 5, "long": 9, "other": float("inf")}
         page_threshold = standards[paper_type.lower()]
-        candidates = {"References", "Acknowledgments", "Acknowledgement", "Acknowledgment", "EthicsStatement", "EthicalConsiderations", "Ethicalconsiderations", "BroaderImpact", "EthicalConcerns", "EthicalStatement", "EthicalDeclaration"}
+        candidates = {"References", "Acknowledgments", "Acknowledgement", "Acknowledgment", "EthicsStatement", "EthicalConsiderations", "Ethicalconsiderations", "BroaderImpact", "EthicalConcerns", "EthicalStatement", "EthicalDeclaration", "Limitations"}
         #acks = {"Acknowledgment", "Acknowledgement"}
 
         # Find (references, acknowledgements, ethics).


### PR DESCRIPTION
EMNLP 2022 submissions require a 'Limitations' section that does not count towards the page limit (https://2022.emnlp.org/calls/main_conference_papers/#submissions:~:text=will%20not%20count%20towards%20the%20page%20limit.) . This PR adds the 'Limitations' section name to the list of candidates to exclude when checking for page limit. This resolves #46.