### PR TITLE
change demo paper standard threshold

### DIFF
--- a/aclpubcheck/formatchecker.py
+++ b/aclpubcheck/formatchecker.py
@@ -319,7 +319,7 @@ class Formatter(object):
         # TODO: Enable uploading a paper_type file to include all papers' types.
 
         # thresholds for different types of papers
-        standards = {"short": 5, "long": 9, "demo": 6, "other": float("inf")}
+        standards = {"short": 5, "long": 9, "demo": 7, "other": float("inf")}
         page_threshold = standards[paper_type.lower()]
         candidates = {"References", "Acknowledgments", "Acknowledgement", "Acknowledgment", "EthicsStatement", "EthicalConsiderations", "Ethicalconsiderations", "BroaderImpact", "EthicalConcerns", "EthicalStatement", "EthicalDeclaration", "Limitations"}
         #acks = {"Acknowledgment", "Acknowledgement"}


### PR DESCRIPTION
Demo papers have 7 pages as their standard thresholds (if accepted), as can be seen here: https://2023.aclweb.org/calls/system_demonstration/ . Other standards for short and long papers take into account the accepted paper, so the demo should do so as well.