### PR TITLE
add setuptools dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ install_requires = [
 	"rebiber<2.0.0",  # 2.0 introduces breaking changes
 	"pybtex",
 	"pylatexenc",
+	"setuptools",
 	"Unidecode",
 	"tsv"
 ]


### PR DESCRIPTION
This is more an issue on the side of `pybtex` than of aclpubcheck but rather than wait for an upstream change, it might be worthwhile to change it here instead.

When running (not when installing), `pybtex` depends on pkg_resources, which is delivered alongside `setuptools`. However, not all python installations have pip (and no setuptools), notably those running with `uv` in modern installations. That will lead to this error:

```
pybtex\plugin\__init__.py", line 26, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

Adding setuptools explicitly will solve the issue.