### PR TITLE
Relaxed matching of font names

### DIFF
--- a/aclpubcheck/formatchecker.py
+++ b/aclpubcheck/formatchecker.py
@@ -384,12 +384,12 @@ class Formatter(object):
     def check_font(self):
         """ Checks the fonts. """
 
-        correct_fontnames = set(["NimbusRomNo9L-Regu",
-                                 "TeXGyreTermesX-Regular",
-                                 "TeXGyreTermes-Regular",
+        correct_fontnames = set(["NimbusRomNo9L-Reg",
+                                 "TeXGyreTermesX-Reg",
+                                 "TeXGyreTermes-Reg",
                                  "TimesNewRomanPSMT",
-                                 "ICWANT+STIXGeneral-Regular",
-                                 "ICZIZQ+Inconsolatazi4-Regular"
+                                 "ICWANT+STIXGeneral-Reg",
+                                 "ICZIZQ+Inconsolatazi4-Reg"
                                  ])
 
         fonts = defaultdict(int)

--- a/aclpubcheck/formatchecker.py
+++ b/aclpubcheck/formatchecker.py
@@ -386,6 +386,7 @@ class Formatter(object):
 
         correct_fontnames = set(["NimbusRomNo9L-Regu",
                                  "TeXGyreTermesX-Regular",
+                                 "TeXGyreTermes-Regular",
                                  "TimesNewRomanPSMT",
                                  "ICWANT+STIXGeneral-Regular",
                                  "ICZIZQ+Inconsolatazi4-Regular"
@@ -406,7 +407,7 @@ class Formatter(object):
         if max_font_count / sum_char_count < 0.35:  # the most used font should be used more than 35% of the time
             self.logs[Error.FONT] += ["Can't find the main font"]
 
-        if not any([max_font_name.endswith(correct_fontname) for correct_fontname in correct_fontnames]):  # the most used font should be `correct_fontname`
+        if not any([correct_fontname in max_font_name for correct_fontname in correct_fontnames]):  # the most used font should be `correct_fontname`
             self.logs[Error.FONT] += [f"Wrong font. The main font used is {max_font_name} when it should a font in {correct_fontnames}."]
 
     def make_name_check_config(self):


### PR DESCRIPTION
This pull request relaxes the matching of font names:

- The name of the correct font can now appear in the middle of the font name, not just at the end. 
- The new version permits TeX Gyre Termes, in addition to TeX Gyre Termes X.

I have a paper in EMNLP Findings 2025 that we prepared using [Typst](https://typst.app/) and the [tracl](https://typst.app/universe/package/tracl/) template. Perhaps Typst handles font names differently when embedding them, compared to LaTeX; but our PDF file causes an error in aclpubcheck because the font name is `PGFQOI+NimbusRomNo9L-Reg-Identity-H`. That's why I would appreciate it if we could relax the font name matching a little.

